### PR TITLE
server: fix immutable listener

### DIFF
--- a/server/server.v
+++ b/server/server.v
@@ -20,7 +20,7 @@ pub interface Router {
 // serve starts the server at the give port
 pub fn serve(router Router, port int) {
 	println('[vex] Vex HTTP Server has started.\n[vex] Serving on http://localhost:$port')
-	listener := net.listen_tcp(port) or { panic('Failed to listen to port $port') }
+	mut listener := net.listen_tcp(port) or { panic('Failed to listen to port $port') }
 	for {
 		mut conn := listener.accept() or {
 			listener.close() or { }


### PR DESCRIPTION
Fixes error `listener is immutable` in `server.v:25:15` and `server.v:26:4` when compiling.

Tested using the [Hello World example](https://github.com/nedpals/vex/blob/master/examples/simple_example.v).