### PR TITLE
session: fix `session.Session` unusable due to recent V update

### DIFF
--- a/session/session.v
+++ b/session/session.v
@@ -11,7 +11,7 @@ import utils
 pub const default_session_name = 'VEXSESID'
 
 // Session contains user data, the session Store, and cookie information
-struct Session {
+pub struct Session {
 	ctx.Cookie
 mut:
 	data map[string]string
@@ -36,6 +36,7 @@ pub fn (mut s Session) set(key string, val string) {
 	}
 }
 
+// set_many sets multiple keys and values in the session data
 pub fn (mut s Session) set_many(keyval ...string) ? {
 	if keyval.len % 2 != 0 {
 		return error('Mismatched key-value pairs.')


### PR DESCRIPTION
One of the recent V commits made it where you can't use private structs as function parameters. i.e. You can't do `fn do_something(ses session.Session)`. Previously you could. Also added a comment above a function I seemed to have missed.