### PR TITLE
fix V deprecation notice about `import sqlite`

### DIFF
--- a/examples/db_example.v
+++ b/examples/db_example.v
@@ -4,7 +4,7 @@ import nedpals.vex.router
 import nedpals.vex.server
 import nedpals.vex.html
 import nedpals.vex.ctx
-import sqlite
+import db.sqlite
 import context
 
 fn layout(title string, body []html.Tag) html.Tag {


### PR DESCRIPTION
This PR just uses `import db.sqlite` instead.