### PR TITLE
Fix varaible naming to prevent symbol shadowing

### DIFF
--- a/examples/login_session_example.v
+++ b/examples/login_session_example.v
@@ -154,10 +154,10 @@ fn main() {
 		return
 	}
 
-	mut router := router.new()
-	router.route(.get, '/profile', profile)
-	router.route(.get, '/login', login)
-	router.route(.post, '/login', login_post)
-	router.route(.post, '/logout', logout_post)
-	server.serve(router, 8080)
+	mut router_ := router.new()
+	router_.route(.get, '/profile', profile)
+	router_.route(.get, '/login', login)
+	router_.route(.post, '/login', login_post)
+	router_.route(.post, '/logout', logout_post)
+	server.serve(router_, 8080)
 }

--- a/picoserver/server.v
+++ b/picoserver/server.v
@@ -14,7 +14,7 @@ struct Server {
 	router Router
 }
 
-fn callback(mut server Server, req picohttpparser.Request, mut res picohttpparser.Response) {
+fn callback(mut server_ Server, req picohttpparser.Request, mut res picohttpparser.Response) {
 	mut req_headers := []string{}
 	for i in 0 .. req.num_headers {
 		unsafe {
@@ -23,7 +23,7 @@ fn callback(mut server Server, req picohttpparser.Request, mut res picohttpparse
 			req_headers << '$name: $value'
 		}
 	}
-	status_code, headers, body := server.router.receive(req.method, req.path, req_headers,
+	status_code, headers, body := server_.router.receive(req.method, req.path, req_headers,
 		req.body.bytes())
 	status_message := http.status_from_int(status_code)
 	res.write_string('HTTP/1.1 $status_code $status_message')

--- a/router/router.v
+++ b/router/router.v
@@ -123,8 +123,8 @@ pub fn (mut r Router) inject(data voidptr) {
 // inject_context injects the context to the handler context.
 // TODO: to be removed in the future. must be in a form of
 // a middleware instead.
-pub fn (mut r Router) inject_context(ctx context.Context) {
-	r.ctx = ctx
+pub fn (mut r Router) inject_context(ctx_ context.Context) {
+	r.ctx = ctx_
 }
 
 // route is a shortcut method to `r.routes.route` method


### PR DESCRIPTION
- Fix #64, rename multiple varaible's naming to prevent symbol shadowing